### PR TITLE
Added scrollOnItemChange prop to force scrollToIndex behaviour on list update.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -100,9 +100,6 @@ export default class VirtualList extends PureComponent {
 
     if (itemPropsHaveChanged) {
       this.recomputeSizes();
-      if (scrollOnItemChange) {
-        this.forceUpdate();
-      }
     }
 
     if (nextProps.scrollOffset !== scrollOffset) {
@@ -111,7 +108,7 @@ export default class VirtualList extends PureComponent {
       });
     } else if (
       scrollPropsHaveChanged ||
-      nextProps.scrollToIndex && itemPropsHaveChanged
+      (scrollOnItemChange || nextProps.scrollToIndex) && itemPropsHaveChanged
     ) {
       this.setState({
         offset: this.getOffsetForIndex(nextProps.scrollToIndex, nextProps.scrollToAlignment, nextProps.itemCount),

--- a/src/index.js
+++ b/src/index.js
@@ -21,6 +21,7 @@ export default class VirtualList extends PureComponent {
     overscanCount: 3,
     scrollDirection: DIRECTION_VERTICAL,
     width: '100%',
+    scrollOnItemChange: false,
   };
   static propTypes = {
     estimatedItemSize: PropTypes.number,
@@ -34,7 +35,8 @@ export default class VirtualList extends PureComponent {
     scrollToAlignment: PropTypes.oneOf([ALIGN_START, ALIGN_CENTER, ALIGN_END]),
     scrollDirection: PropTypes.oneOf([DIRECTION_HORIZONTAL, DIRECTION_VERTICAL]).isRequired,
     width: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
-  }
+    scrollOnItemChange: PropTypes.bool,
+  };
 
   sizeAndPositionManager = new SizeAndPositionManager({
     itemCount: this.props.itemCount,
@@ -74,6 +76,7 @@ export default class VirtualList extends PureComponent {
       scrollOffset,
       scrollToAlignment,
       scrollToIndex,
+      scrollOnItemChange,
     } = this.props;
     const scrollPropsHaveChanged = (
       nextProps.scrollToIndex !== scrollToIndex ||
@@ -97,6 +100,9 @@ export default class VirtualList extends PureComponent {
 
     if (itemPropsHaveChanged) {
       this.recomputeSizes();
+      if (scrollOnItemChange) {
+        this.forceUpdate();
+      }
     }
 
     if (nextProps.scrollOffset !== scrollOffset) {

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -15,6 +15,7 @@ describe('VirtualList', () => {
         overscanCount={0}
         itemSize={ITEM_HEIGHT}
         itemCount={500}
+        scrollOnItemChange={false}
         renderItem={({index, style}) => (
           <div className="item" key={index} style={style}>
             Item #{index}
@@ -126,6 +127,16 @@ describe('VirtualList', () => {
       // Making rows taller pushes name off/beyond the scrolled area
       rendered = findDOMNode(
         render(getComponent({scrollToIndex: 50, itemSize: 20}), node),
+      );
+      expect(rendered.textContent).toContain('Item #50');
+    });
+
+    it('updates :scrollToIndex position when :itemCount changes and scrollOnItemChange flag is set', () => {
+      let rendered = findDOMNode(render(getComponent({scrollToIndex: 50, itemCount: 500, scrollOnItemChange: true}), node));
+      expect(rendered.textContent).toContain('Item #50');
+      // Making rows taller pushes name off/beyond the scrolled area
+      rendered = findDOMNode(
+        render(getComponent({scrollToIndex: 50, itemCount: 60, scrollOnItemChange: true}), node),
       );
       expect(rendered.textContent).toContain('Item #50');
     });


### PR DESCRIPTION
Our project needed the virtual list to always scroll to item 0 on update. 
Doing this via setting the scrollToIndex was not viable as some of our list states have 0 length.
