### PR TITLE
chore: Add forceUpdate to the documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,9 @@ render(
 
 ### Public Methods
 
+#### forceUpdate ()
+This method force renders the list. Use when list order changes with sorting.
+
 #### recomputeSizes (index: number)
 This method force recomputes the item sizes after the specificed index (these are normally cached).
 


### PR DESCRIPTION
Prevent confusion when sorting items and not seeing the `<VirtualList/>` change.