### PR TITLE
Fix misuse of second argument as nextState (the actual argument is prevState)

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -183,10 +183,10 @@ export default class VirtualList extends React.PureComponent<Props, State> {
     }
   }
 
-  componentDidUpdate(_: Props, nextState: State) {
-    const {offset} = this.state;
+  componentDidUpdate(_: Props, prevState: State) {
+    const {offset, scrollChangeReason} = this.state;
 
-    if (nextState.offset !== offset && nextState.scrollChangeReason === SCROLL_CHANGE_REQUESTED) {
+    if (prevState.offset !== offset && scrollChangeReason === SCROLL_CHANGE_REQUESTED) {
       this.scrollTo(offset);
     }
   }


### PR DESCRIPTION
I am working on a horizontal timeline that uses `react-tiny-virtual-list` to reduce the amount of items rendered at any one time. Clicking on an item on this timeline should center it horizontally. I noticed that when clicking on an item after scrolling, the item would not center. 

This fixes instances where, right after scrolling, a change in the `scrollToIndex` prop will not actually scroll to the item at the passed index correctly. This is due to the `componentDidUpdate` method considering the previous state to actually be the next state and looking at `scrollChangeReason` on it, seeing the old `scrollChangeReason` caused by the user scrolling, thus not calling `scrollTo` to actually center the element.