### PR TITLE
Updated README with information on how to trigger re-render for sorted data.

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,13 @@ This method force recomputes the item sizes after the specified index (these are
 `VirtualList` has no way of knowing when its underlying data has changed, since it only receives a itemSize property. If the itemSize is a `number`, this isn't an issue, as it can compare before and after values and automatically call `recomputeSizes` internally.
  However, if you're passing a function to `itemSize`, that type of comparison is error prone. In that event, you'll need to call `recomputeSizes` manually to inform the `VirtualList` that the size of its items has changed.
 
+### Note
+If you are using react-tiny-virtual-list to show a list which can be sorted you might encounter this scenario:
+
+On sorting the data, there is no effect on the rendered list. But when scrolled, the list gets re-rendered.
+
+`List` uses [PureComponent](https://reactjs.org/docs/react-api.html#reactpurecomponent), so it only updates when it's props change. You can force it to re-render by calling [forceUpdate](https://reactjs.org/docs/react-component.html#forceupdate) on it or by passing it an extra prop that will change every time your data changes.
+
 ## Reporting Issues
 Found an issue? Please [report it](https://github.com/clauderic/react-tiny-virtual-list/issues) along with any relevant details to reproduce it.
 

--- a/README.md
+++ b/README.md
@@ -99,11 +99,9 @@ This method force recomputes the item sizes after the specified index (these are
  However, if you're passing a function to `itemSize`, that type of comparison is error prone. In that event, you'll need to call `recomputeSizes` manually to inform the `VirtualList` that the size of its items has changed.
 
 ### Note
-If you are using react-tiny-virtual-list to show a list which can be sorted you might encounter this scenario:
+`react-tiny-virtual-list` uses [PureComponent](https://reactjs.org/docs/react-api.html#reactpurecomponent), so it only updates when it's props change. Therefore, if only the order of your data changes (eg ['a','b','c'] => ['d','e','f']), `react-tiny-virtual-list` has no way to know your data has changed and that it needs to re-render.
 
-On sorting the data, there is no effect on the rendered list. But when scrolled, the list gets re-rendered.
-
-`List` uses [PureComponent](https://reactjs.org/docs/react-api.html#reactpurecomponent), so it only updates when it's props change. You can force it to re-render by calling [forceUpdate](https://reactjs.org/docs/react-component.html#forceupdate) on it or by passing it an extra prop that will change every time your data changes.
+You can force it to re-render by calling [forceUpdate](https://reactjs.org/docs/react-component.html#forceupdate) on it or by passing it an extra prop that will change every time your data changes.
 
 ## Reporting Issues
 Found an issue? Please [report it](https://github.com/clauderic/react-tiny-virtual-list/issues) along with any relevant details to reproduce it.

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ This method force recomputes the item sizes after the specified index (these are
 `VirtualList` has no way of knowing when its underlying data has changed, since it only receives a itemSize property. If the itemSize is a `number`, this isn't an issue, as it can compare before and after values and automatically call `recomputeSizes` internally.
  However, if you're passing a function to `itemSize`, that type of comparison is error prone. In that event, you'll need to call `recomputeSizes` manually to inform the `VirtualList` that the size of its items has changed.
 
-### Note
+### Common Issues with PureComponent 
 `react-tiny-virtual-list` uses [PureComponent](https://reactjs.org/docs/react-api.html#reactpurecomponent), so it only updates when it's props change. Therefore, if only the order of your data changes (eg ['a','b','c'] => ['d','e','f']), `react-tiny-virtual-list` has no way to know your data has changed and that it needs to re-render.
 
 You can force it to re-render by calling [forceUpdate](https://reactjs.org/docs/react-component.html#forceupdate) on it or by passing it an extra prop that will change every time your data changes.


### PR DESCRIPTION
From issue #34 

When using react-tiny-virtual-list to show a list which can be sorted. On sorting the data, there is no effect on the rendered list. But when scrolled, the list gets re-rendered.

I think this is something that should be there in the documentation.