### PR TITLE
Add support for sticky items

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 </div>
 
 # react-tiny-virtual-list
+
 > A tiny but mighty list virtualization library, with zero dependencies 💪
 
 [![npm version](https://img.shields.io/npm/v/react-tiny-virtual-list.svg)](https://www.npmjs.com/package/react-tiny-virtual-list)
@@ -13,28 +14,30 @@
 [![license](https://img.shields.io/github/license/mashape/apistatus.svg?maxAge=2592000)](https://github.com/clauderic/react-tiny-virtual-list/blob/master/LICENSE)
 [![Gitter](https://badges.gitter.im/clauderic/react-tiny-virtual-list.svg)](https://gitter.im/clauderic/react-tiny-virtual-list)
 
-* **Tiny & dependency free** – Only 3kb gzipped
-* **Render millions of items**, without breaking a sweat
-* **Scroll to index** or **set the initial scroll offset**
-* **Supports fixed** or **variable** heights/widths
-* **Vertical** or **Horizontal** lists
+- **Tiny & dependency free** – Only 3kb gzipped
+- **Render millions of items**, without breaking a sweat
+- **Scroll to index** or **set the initial scroll offset**
+- **Supports fixed** or **variable** heights/widths
+- **Vertical** or **Horizontal** lists
 
 Check out the [demo](https://clauderic.github.io/react-tiny-virtual-list/) for some examples, or take it for a test drive right away in [Code Sandbox](https://codesandbox.io/s/kymm7z9qr).
 
-Getting Started
----------------
+## Getting Started
 
 Using [npm](https://www.npmjs.com/):
+
 ```
 npm install react-tiny-virtual-list --save
 ```
 
 ES6, CommonJS, and UMD builds are available with each distribution. For example:
+
 ```js
 import VirtualList from 'react-tiny-virtual-list';
 ```
 
 You can also use a global-friendly UMD build:
+
 ```html
 <script src="react-tiny-virtual-list/umd/react-tiny-virtual-list.js"></script>
 <script>
@@ -43,8 +46,7 @@ var VirtualList = window.VirtualList;
 </script>
 ```
 
-Example usage
--------------
+## Example usage
 
 ```js
 import React from 'react';
@@ -70,45 +72,53 @@ render(
 ```
 
 ### Prop Types
-| Property          | Type              | Required? | Description                                                                                                                                                                                                                                                                                                                                                                                                                          |
-|:------------------|:------------------|:----------|:-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| width             | Number or String* | ✓         | Width of List. This property will determine the number of rendered items when scrollDirection is `'horizontal'`.                                                                                                                                                                                                                                                                                                                     |
-| height            | Number or String* | ✓         | Height of List. This property will determine the number of rendered items when scrollDirection is `'vertical'`.                                                                                                                                                                                                                                                                                                                      |
-| itemCount         | Number            | ✓         | The number of items you want to render                                                                                                                                                                                                                                                                                                                                                                                               |
-| renderItem        | Function          | ✓         | Responsible for rendering an item given it's index: `({index: number, style: Object}): React.PropTypes.node`. The returned element must handle key and style.                                                                                                                                                                                                                                                                        |
-| itemSize          |                   | ✓         | Either a fixed height/width (depending on the scrollDirection), an array containing the heights of all the items in your list, or a function that returns the height of an item given its index: `(index: number): number`                                                                                                                                                                                                           |
-| scrollDirection   | String            |           | Whether the list should scroll vertically or horizontally. One of `'vertical'` (default) or `'horizontal'`.                                                                                                                                                                                                                                                                                                                          |
-| scrollOffset      | Number            |           | Can be used to control the scroll offset; Also useful for setting an initial scroll offset                                                                                                                                                                                                                                                                                                                                           |
-| scrollToIndex     | Number            |           | Item index to scroll to (by forcefully scrolling if necessary)                                                                                                                                                                                                                                                                                                                                                                       |
-| scrollToAlignment | String            |           | Used in combination with `scrollToIndex`, this prop controls the alignment of the scrolled to item. One of: `'start'`, `'center'`, `'end'` or `'auto'`. Use `'start'` to always align items to the top of the container and `'end'` to align them bottom. Use `'center`' to align them in the middle of the container. `'auto'` scrolls the least amount possible to ensure that the specified `scrollToIndex` item is fully visible. |
-| overscanCount     | Number            |           | Number of extra buffer items to render above/below the visible items. Tweaking this can help reduce scroll flickering on certain browsers/devices.                                                                                                                                                                                                                                                                                   |
-| estimatedItemSize | Number            |           | Used to estimate the total size of the list before all of its items have actually been measured. The estimated total height is progressively adjusted as items are rendered.                                                                                                                                                                                                                                                         |
-| onItemsRendered    | Function          |           | Callback invoked with information about the slice of rows/columns that were just rendered. It has the following signature: `({startIndex: number, stopIndex: number})`.                                                                                                                                                                                                                                                                      |
-| onScroll          | Function          |           | Callback invoked whenever the scroll offset changes within the inner scrollable region. It has the following signature: `(scrollTop: number, event: React.UIEvent<HTMLDivElement>)`.                                                                                                                                                                                                                                                 |
 
-*\* Width may only be a string when `scrollDirection` is `'vertical'`. Similarly, Height may only be a string if `scrollDirection` is `'horizontal'`*
+| Property          | Type               | Required? | Description                                                                                                                                                                                                                                                                                                                                                                                                                           |
+| :---------------- | :----------------- | :-------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| width             | Number \| String\* | ✓         | Width of List. This property will determine the number of rendered items when scrollDirection is `'horizontal'`.                                                                                                                                                                                                                                                                                                                      |
+| height            | Number \| String\* | ✓         | Height of List. This property will determine the number of rendered items when scrollDirection is `'vertical'`.                                                                                                                                                                                                                                                                                                                       |
+| itemCount         | Number             | ✓         | The number of items you want to render                                                                                                                                                                                                                                                                                                                                                                                                |
+| renderItem        | Function           | ✓         | Responsible for rendering an item given it's index: `({index: number, style: Object}): React.PropTypes.node`. The returned element must handle key and style.                                                                                                                                                                                                                                                                         |
+| itemSize          |                    | ✓         | Either a fixed height/width (depending on the scrollDirection), an array containing the heights of all the items in your list, or a function that returns the height of an item given its index: `(index: number): number`                                                                                                                                                                                                            |
+| scrollDirection   | String             |           | Whether the list should scroll vertically or horizontally. One of `'vertical'` (default) or `'horizontal'`.                                                                                                                                                                                                                                                                                                                           |
+| scrollOffset      | Number             |           | Can be used to control the scroll offset; Also useful for setting an initial scroll offset                                                                                                                                                                                                                                                                                                                                            |
+| scrollToIndex     | Number             |           | Item index to scroll to (by forcefully scrolling if necessary) x                                                                                                                                                                                                                                                                                                                                                                      |
+| scrollToAlignment | String             |           | Used in combination with `scrollToIndex`, this prop controls the alignment of the scrolled to item. One of: `'start'`, `'center'`, `'end'` or `'auto'`. Use `'start'` to always align items to the top of the container and `'end'` to align them bottom. Use `'center`' to align them in the middle of the container. `'auto'` scrolls the least amount possible to ensure that the specified `scrollToIndex` item is fully visible. |
+| stickyIndices     | Number[]           |           | An array of indexes (eg. `[0, 10, 25, 30]`) to make certain items in the list sticky (`position: sticky`)                                                                                                                                                                                                                                                                                                                             |
+| overscanCount     | Number             |           | Number of extra buffer items to render above/below the visible items. Tweaking this can help reduce scroll flickering on certain browsers/devices.                                                                                                                                                                                                                                                                                    |
+| estimatedItemSize | Number             |           | Used to estimate the total size of the list before all of its items have actually been measured. The estimated total height is progressively adjusted as items are rendered.                                                                                                                                                                                                                                                          |
+| onItemsRendered   | Function           |           | Callback invoked with information about the slice of rows/columns that were just rendered. It has the following signature: `({startIndex: number, stopIndex: number})`.                                                                                                                                                                                                                                                               |
+| onScroll          | Function           |           | Callback invoked whenever the scroll offset changes within the inner scrollable region. It has the following signature: `(scrollTop: number, event: React.UIEvent<HTMLDivElement>)`.                                                                                                                                                                                                                                                  |
+
+_\* Width may only be a string when `scrollDirection` is `'vertical'`. Similarly, Height may only be a string if `scrollDirection` is `'horizontal'`_
 
 ### Public Methods
 
 #### recomputeSizes (index: number)
+
 This method force recomputes the item sizes after the specified index (these are normally cached).
 
 `VirtualList` has no way of knowing when its underlying data has changed, since it only receives a itemSize property. If the itemSize is a `number`, this isn't an issue, as it can compare before and after values and automatically call `recomputeSizes` internally.
- However, if you're passing a function to `itemSize`, that type of comparison is error prone. In that event, you'll need to call `recomputeSizes` manually to inform the `VirtualList` that the size of its items has changed.
+However, if you're passing a function to `itemSize`, that type of comparison is error prone. In that event, you'll need to call `recomputeSizes` manually to inform the `VirtualList` that the size of its items has changed.
 
-### Common Issues with PureComponent 
+### Common Issues with PureComponent
+
 `react-tiny-virtual-list` uses [PureComponent](https://reactjs.org/docs/react-api.html#reactpurecomponent), so it only updates when it's props change. Therefore, if only the order of your data changes (eg `['a','b','c']` => `['d','e','f']`), `react-tiny-virtual-list` has no way to know your data has changed and that it needs to re-render.
 
 You can force it to re-render by calling [forceUpdate](https://reactjs.org/docs/react-component.html#forceupdate) on it or by passing it an extra prop that will change every time your data changes.
 
 ## Reporting Issues
+
 Found an issue? Please [report it](https://github.com/clauderic/react-tiny-virtual-list/issues) along with any relevant details to reproduce it. If you can, please provide a live demo replicating the issue you're describing. You can [fork this Code Sandbox](https://codesandbox.io/s/kymm7z9qr) as a starting point.
 
 ## Contributions
+
 Feature requests / pull requests are welcome, though please take a moment to make sure your contributions fits within the scope of the project. [Learn how to contribute](https://github.com/clauderic/react-tiny-virtual-list/blob/master/CONTRIBUTING.md)
 
 ## Acknowledgments
+
 This library draws inspiration from [react-virtualized](https://github.com/bvaughn/react-virtualized), and is meant as a bare-minimum replacement for the [List](https://github.com/bvaughn/react-virtualized/blob/master/docs/List.md) component. If you're looking for a tiny, lightweight and dependency-free list virtualization library that supports variable heights, you're in the right place! If you're looking for something that supports more use-cases, I highly encourage you to check out [react-virtualized](https://github.com/bvaughn/react-virtualized) instead, it's a fantastic library ❤️
 
 ## License
+
 react-tiny-virtual-list is available under the MIT License.

--- a/examples/sticky-headers.tsx
+++ b/examples/sticky-headers.tsx
@@ -1,0 +1,42 @@
+import * as React from 'react';
+import * as ReactDOM from 'react-dom';
+
+import VirtualList, {ItemStyle} from '../src';
+import './demo.css';
+
+const stickyIndices = [0, 5, 8, 15, 30, 50, 100, 200];
+
+class StickyHeaders extends React.Component {
+  renderItem = ({style, index}: {style: ItemStyle; index: number}) => {
+    const itemStyle = stickyIndices.includes(index)
+      ? {
+          ...style,
+          backgroundColor: '#EEE',
+        }
+      : style;
+
+    return (
+      <div className="Row" style={itemStyle} key={index}>
+        Row #{index}
+      </div>
+    );
+  };
+
+  render() {
+    return (
+      <div className="Root">
+        <VirtualList
+          width="auto"
+          height={400}
+          itemCount={1000}
+          renderItem={this.renderItem}
+          itemSize={50}
+          className="VirtualList"
+          stickyIndices={stickyIndices}
+        />
+      </div>
+    );
+  }
+}
+
+ReactDOM.render(<StickyHeaders />, document.querySelector('#app'));

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -29,3 +29,13 @@ export const positionProp = {
   [DIRECTION.VERTICAL]: 'top',
   [DIRECTION.HORIZONTAL]: 'left',
 };
+
+export const marginProp = {
+  [DIRECTION.VERTICAL]: 'marginTop',
+  [DIRECTION.HORIZONTAL]: 'marginLeft',
+};
+
+export const oppositeMarginProp = {
+  [DIRECTION.VERTICAL]: 'marginBottom',
+  [DIRECTION.HORIZONTAL]: 'marginRight',
+};

--- a/tests/index.test.tsx
+++ b/tests/index.test.tsx
@@ -5,17 +5,17 @@ import VirtualList from '../src';
 const HEIGHT = 100;
 const ITEM_HEIGHT = 10;
 
+interface ItemAttributes {
+  index: number;
+  style: React.CSSProperties;
+  className?: string;
+}
+
 describe('VirtualList', () => {
   let node: HTMLDivElement;
-  function renderItem({
-    index,
-    style,
-  }: {
-    index: number;
-    style: React.CSSProperties;
-  }) {
+  function renderItem({index, style, ...props}: ItemAttributes) {
     return (
-      <div className="item" key={index} style={style}>
+      <div className="item" key={index} style={style} {...props}>
         Item #{index}
       </div>
     );
@@ -55,6 +55,49 @@ describe('VirtualList', () => {
         render(getComponent({itemCount}), node);
         expect(node.querySelectorAll('.item')).toHaveLength(itemCount);
       }
+    });
+
+    describe('stickyIndices', () => {
+      const stickyIndices = [0, 10, 20, 30, 50];
+
+      function itemRenderer({index, style}) {
+        return renderItem({
+          index,
+          style,
+          className: stickyIndices.includes(index) ? 'item sticky' : 'item',
+        });
+      }
+
+      it('renders all sticky indices when scrollTop is zero', () => {
+        render(
+          getComponent({
+            itemCount: 100,
+            stickyIndices,
+            renderItem: itemRenderer,
+          }),
+          node,
+        );
+
+        expect(node.querySelectorAll('.sticky')).toHaveLength(
+          stickyIndices.length,
+        );
+      });
+
+      it('keeps sticky indices rendered when scrolling', () => {
+        render(
+          getComponent({
+            itemCount: 100,
+            stickyIndices,
+            renderItem: itemRenderer,
+            scrollOffset: 500,
+          }),
+          node,
+        );
+
+        expect(node.querySelectorAll('.sticky')).toHaveLength(
+          stickyIndices.length,
+        );
+      });
     });
   });
 


### PR DESCRIPTION
This PR adds a `stickyIndices` prop to add support for sticky headers:

<img src="https://user-images.githubusercontent.com/1416436/41815604-4288c804-773e-11e8-9a0c-32bb6a1735f7.gif" width="350" />

The prop accepts an array of indices that should be made sticky (eg, `stickyIndices={[0, 20, 50, 100]}`)

The solution relies on `position: sticky`, so it will only work in browsers that support that feature, but will degrade gracefully for other browsers.

It also works with horizontal lists:

<img src="https://user-images.githubusercontent.com/1416436/41815702-b7243070-7740-11e8-9256-937659df283b.gif" width="420" />

### How to test locally
Clone the project and check out this branch. Run `yarn` followed by `npm start`.

### To-do

- [x] Update documentation
- [x] Add test coverage for `stickyIndices`
- [ ] Update demo site