### PR TITLE
Fix itemSizeGetter bug when `scrollToIndex` is defined

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -10,6 +10,7 @@
     "no-param-reassign": "off",
     "react/no-unused-prop-types": "off",
     "react/jsx-filename-extension": [1, { "extensions": [".tsx"] }],
+    "typescript/member-ordering": "off",
     "jest/consistent-test-it": [
       "error",
       {

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "rollup-plugin-babel": "^3.0.2",
     "rollup-plugin-commonjs": "^8.2.0",
     "rollup-plugin-node-resolve": "^3.0.0",
+    "rollup-plugin-typescript2": "^0.15.0",
     "rollup-plugin-uglify": "^2.0.1",
     "tslint": "^5.10.0",
     "tslint-config-shopify": "^3.0.2",

--- a/src/SizeAndPositionManager.ts
+++ b/src/SizeAndPositionManager.ts
@@ -40,13 +40,20 @@ export default class SizeAndPositionManager {
 
   updateConfig({
     itemCount,
+    itemSizeGetter,
     estimatedItemSize,
-  }: {
-    itemCount: number;
-    estimatedItemSize: number;
-  }) {
-    this.itemCount = itemCount;
-    this.estimatedItemSize = estimatedItemSize;
+  }: Partial<Options>) {
+    if (itemCount != null) {
+      this.itemCount = itemCount;
+    }
+
+    if (estimatedItemSize != null) {
+      this.estimatedItemSize = estimatedItemSize;
+    }
+
+    if (itemSizeGetter != null) {
+      this.itemSizeGetter = itemSizeGetter;
+    }
   }
 
   getLastMeasuredIndex() {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -120,13 +120,13 @@ export default class VirtualList extends React.PureComponent<Props, State> {
     width: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
   };
 
-  itemSizeGetter = (props: Props) => {
-    return index => this.getSize(index, props.itemSize);
+  itemSizeGetter = (itemSize: Props['itemSize']) => {
+    return index => this.getSize(index, itemSize);
   };
 
   sizeAndPositionManager = new SizeAndPositionManager({
     itemCount: this.props.itemCount,
-    itemSizeGetter: this.itemSizeGetter(this.props),
+    itemSizeGetter: this.itemSizeGetter(this.props.itemSize),
     estimatedItemSize: this.getEstimatedItemSize(),
   });
 
@@ -173,9 +173,11 @@ export default class VirtualList extends React.PureComponent<Props, State> {
       nextProps.itemSize !== itemSize ||
       nextProps.estimatedItemSize !== estimatedItemSize;
 
-    this.sizeAndPositionManager.updateConfig({
-      itemSizeGetter: this.itemSizeGetter(nextProps),
-    });
+    if (nextProps.itemSize !== itemSize) {
+      this.sizeAndPositionManager.updateConfig({
+        itemSizeGetter: this.itemSizeGetter(nextProps.itemSize),
+      });
+    }
 
     if (
       nextProps.itemCount !== itemCount ||

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -120,9 +120,13 @@ export default class VirtualList extends React.PureComponent<Props, State> {
     width: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
   };
 
+  itemSizeGetter = (props: Props) => {
+    return index => this.getSize(index, props.itemSize);
+  };
+
   sizeAndPositionManager = new SizeAndPositionManager({
     itemCount: this.props.itemCount,
-    itemSizeGetter: index => this.getSize(index),
+    itemSizeGetter: this.itemSizeGetter(this.props),
     estimatedItemSize: this.getEstimatedItemSize(),
   });
 
@@ -168,6 +172,10 @@ export default class VirtualList extends React.PureComponent<Props, State> {
       nextProps.itemCount !== itemCount ||
       nextProps.itemSize !== itemSize ||
       nextProps.estimatedItemSize !== estimatedItemSize;
+
+    this.sizeAndPositionManager.updateConfig({
+      itemSizeGetter: this.itemSizeGetter(nextProps),
+    });
 
     if (
       nextProps.itemCount !== itemCount ||
@@ -344,9 +352,7 @@ export default class VirtualList extends React.PureComponent<Props, State> {
     );
   }
 
-  private getSize(index: number) {
-    const {itemSize} = this.props;
-
+  private getSize(index: number, itemSize) {
     if (typeof itemSize === 'function') {
       return itemSize(index);
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3439,6 +3439,14 @@ fs-extra@^4.0.1:
     jsonfile "^3.0.0"
     universalify "^0.1.0"
 
+fs-extra@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-5.0.0.tgz#414d0110cdd06705734d055652c5411260c31abd"
+  dependencies:
+    graceful-fs "^4.1.2"
+    jsonfile "^4.0.0"
+    universalify "^0.1.0"
+
 fs-extra@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-1.0.0.tgz#cd3ce5f7e7cb6145883fcae3191e9877f8587950"
@@ -4695,6 +4703,12 @@ jsonfile@^2.1.0:
 jsonfile@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-3.0.1.tgz#a5ecc6f65f53f662c4415c7675a0331d0992ec66"
+  optionalDependencies:
+    graceful-fs "^4.1.6"
+
+jsonfile@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-4.0.0.tgz#8771aae0799b64076b76640fca058f9c10e33ecb"
   optionalDependencies:
     graceful-fs "^4.1.6"
 
@@ -6690,7 +6704,7 @@ resolve@^1.1.6, resolve@^1.2.0, resolve@^1.3.2, resolve@^1.4.0:
   dependencies:
     path-parse "^1.0.5"
 
-resolve@^1.3.3, resolve@^1.5.0:
+resolve@^1.3.3, resolve@^1.5.0, resolve@^1.7.1:
   version "1.8.1"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.8.1.tgz#82f1ec19a423ac1fbd080b0bab06ba36e84a7a26"
   dependencies:
@@ -6755,6 +6769,15 @@ rollup-plugin-node-resolve@^3.0.0:
     builtin-modules "^1.1.0"
     is-module "^1.0.0"
     resolve "^1.1.6"
+
+rollup-plugin-typescript2@^0.15.0:
+  version "0.15.0"
+  resolved "https://registry.yarnpkg.com/rollup-plugin-typescript2/-/rollup-plugin-typescript2-0.15.0.tgz#33cf4ec8528f6fa5686cf1246f047acec4801d3a"
+  dependencies:
+    fs-extra "^5.0.0"
+    resolve "^1.7.1"
+    rollup-pluginutils "^2.0.1"
+    tslib "1.9.2"
 
 rollup-plugin-uglify@^2.0.1:
   version "2.0.1"
@@ -7472,6 +7495,10 @@ trim-newlines@^1.0.0:
 trim-right@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/trim-right/-/trim-right-1.0.1.tgz#cb2e1203067e0c8de1f614094b9fe45704ea6003"
+
+tslib@1.9.2:
+  version "1.9.2"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.9.2.tgz#8be0cc9a1f6dc7727c38deb16c2ebd1a2892988e"
 
 tslib@^1.7.1:
   version "1.7.1"


### PR DESCRIPTION
This PR fixes an issue described in #40 where the itemSize was cached incorrectly when `itemSize` changed and `scrollToIndex` was defined.