### PR TITLE
Add prepreCalculateTotalHeight prop

### DIFF
--- a/demo/src/index.tsx
+++ b/demo/src/index.tsx
@@ -4,6 +4,8 @@ import * as ReactDOM from 'react-dom';
 import VirtualList, {ItemStyle} from '../../src';
 import './demo.css';
 
+const range = N => Array.from({length: N}, (_, k) => k + 1);
+
 class Demo extends React.Component {
   renderItem = ({style, index}: {style: ItemStyle; index: number}) => {
     return (
@@ -29,4 +31,50 @@ class Demo extends React.Component {
   }
 }
 
-ReactDOM.render(<Demo />, document.querySelector('#app'));
+class MixedHeight extends React.Component<any, any> {
+  constructor(props: any) {
+    super(props);
+    this.state = {
+      items: range(1000).map(() => {
+        return Math.max(Math.ceil(Math.random() * 1000), 50);
+      }),
+    };
+  }
+
+  renderItem = ({style, index}: {style: ItemStyle; index: number}) => {
+    return (
+      <div className="Row" style={style} key={index}>
+        Row #{index}. Height: #{this.state.items[index]}
+      </div>
+    );
+  };
+
+  render() {
+    return (
+      <div className="Root">
+        <VirtualList
+          preCalculateTotalHeight
+          width="auto"
+          height={400}
+          itemCount={1000}
+          renderItem={this.renderItem}
+          itemSize={this.state.items}
+          className="VirtualList"
+        />
+      </div>
+    );
+  }
+}
+
+class Demos extends React.Component {
+  render() {
+    return (
+      <div className="Root">
+        <Demo />
+        <MixedHeight />
+      </div>
+    );
+  }
+}
+
+ReactDOM.render(<Demos />, document.querySelector('#app'));

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -57,6 +57,7 @@ export interface Props {
   stickyIndices?: number[];
   style?: React.CSSProperties;
   width?: number | string;
+  preCalculateTotalHeight?: boolean; // added this
   onItemsRendered?({startIndex, stopIndex}: RenderedRows): void;
   onScroll?(offset: number, event: UIEvent): void;
   renderItem(itemInfo: ItemInfo): React.ReactNode;
@@ -101,6 +102,7 @@ export default class VirtualList extends React.PureComponent<Props, State> {
     overscanCount: 3,
     scrollDirection: DIRECTION.VERTICAL,
     width: '100%',
+    preCalculateTotalHeight: false,
   };
 
   static propTypes = {
@@ -132,6 +134,7 @@ export default class VirtualList extends React.PureComponent<Props, State> {
     stickyIndices: PropTypes.arrayOf(PropTypes.number),
     style: PropTypes.object,
     width: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+    preCalculateTotalHeight: PropTypes.bool,
   };
 
   itemSizeGetter = (itemSize: Props['itemSize']) => {
@@ -142,6 +145,9 @@ export default class VirtualList extends React.PureComponent<Props, State> {
     itemCount: this.props.itemCount,
     itemSizeGetter: this.itemSizeGetter(this.props.itemSize),
     estimatedItemSize: this.getEstimatedItemSize(),
+    preCalculateTotalHeight:
+      this.props.preCalculateTotalHeight ||
+      VirtualList.defaultProps.preCalculateTotalHeight,
   });
 
   readonly state: State = {
@@ -178,6 +184,7 @@ export default class VirtualList extends React.PureComponent<Props, State> {
       scrollOffset,
       scrollToAlignment,
       scrollToIndex,
+      preCalculateTotalHeight,
     } = this.props;
     const scrollPropsHaveChanged =
       nextProps.scrollToIndex !== scrollToIndex ||
@@ -185,7 +192,14 @@ export default class VirtualList extends React.PureComponent<Props, State> {
     const itemPropsHaveChanged =
       nextProps.itemCount !== itemCount ||
       nextProps.itemSize !== itemSize ||
-      nextProps.estimatedItemSize !== estimatedItemSize;
+      nextProps.estimatedItemSize !== estimatedItemSize ||
+      nextProps.preCalculateTotalHeight !== preCalculateTotalHeight;
+
+    if (nextProps.preCalculateTotalHeight !== preCalculateTotalHeight) {
+      this.sizeAndPositionManager.updateConfig({
+        preCalculateTotalHeight,
+      });
+    }
 
     if (nextProps.itemSize !== itemSize) {
       this.sizeAndPositionManager.updateConfig({
@@ -289,6 +303,7 @@ export default class VirtualList extends React.PureComponent<Props, State> {
       stickyIndices,
       style,
       width,
+      preCalculateTotalHeight,
       ...props
     } = this.props;
     const {offset} = this.state;

--- a/tests/SizeAndPositionManager.test.ts
+++ b/tests/SizeAndPositionManager.test.ts
@@ -3,6 +3,8 @@ import {ALIGNMENT} from '../src/constants';
 
 const ITEM_SIZE = 10;
 
+const range = N => Array.from({length: N}, (_, k) => k + 1);
+
 describe('SizeAndPositionManager', () => {
   function getItemSizeAndPositionManager({
     itemCount = 100,
@@ -21,6 +23,34 @@ describe('SizeAndPositionManager', () => {
     return {
       sizeAndPositionManager,
       itemSizeGetterCalls,
+    };
+  }
+
+  function getItemSizeAndPositionManagerWithPreCalculatedHeight({
+    itemCount = 100,
+    estimatedItemSize = 15,
+  } = {}) {
+    const dynamicHeights = range(itemCount).map(() => {
+      return Math.max(Math.ceil(Math.random() * 1000), 50);
+    });
+
+    const itemSizeGetterCalls: number[] = [];
+    const sizeAndPositionManager = new SizeAndPositionManager({
+      itemCount,
+      itemSizeGetter: (index: number) => {
+        itemSizeGetterCalls.push(index);
+        return dynamicHeights[index];
+      },
+      estimatedItemSize,
+      preCalculateTotalHeight: true,
+    });
+
+    return {
+      sizeAndPositionManager,
+      itemSizeGetterCalls,
+      totalSize: dynamicHeights.reduce((acc, currentValue) => {
+        return acc + currentValue;
+      }, 0),
     };
   }
 
@@ -166,6 +196,16 @@ describe('SizeAndPositionManager', () => {
       const {sizeAndPositionManager} = getItemSizeAndPositionManager();
       sizeAndPositionManager.getSizeAndPositionForIndex(99);
       expect(sizeAndPositionManager.getTotalSize()).toEqual(1000);
+    });
+  });
+
+  describe('getTotalSize when preCalculateTotalHeight is true', () => {
+    it('should calculate total size based on pre calculating the height', () => {
+      const {
+        sizeAndPositionManager,
+        totalSize,
+      } = getItemSizeAndPositionManagerWithPreCalculatedHeight();
+      expect(sizeAndPositionManager.getTotalSize()).toEqual(totalSize);
     });
   });
 


### PR DESCRIPTION
This PR implements a new property for `VirtualList` to allow pre calculation of the total height instead of running an estimate. Implements: #60.

This feature is especially helpful when rendering varying mixed height rows. In the following example

```jsx
<VirtualList
  preCalculateTotalHeight
  width="auto"
  height={400}
  itemCount={1000}
  renderItem={this.renderItem}
  itemSize={this.state.items}
  className="VirtualList"
/>
```

## Before
![scrolling total size](https://user-images.githubusercontent.com/564463/43480809-29d52a8a-94b9-11e8-96a8-6693f5977a90.gif)

## After
![scrolling total size fixed](https://user-images.githubusercontent.com/564463/43480816-2e4cda36-94b9-11e8-8864-7a493a150206.gif)


