### PR TITLE
Expose container ref to users

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -116,6 +116,7 @@ export default class VirtualList extends React.PureComponent<Props, State> {
     onScroll: PropTypes.func,
     onItemsRendered: PropTypes.func,
     overscanCount: PropTypes.number,
+    ref: PropTypes.func,
     renderItem: PropTypes.func.isRequired,
     scrollOffset: PropTypes.number,
     scrollToIndex: PropTypes.number,
@@ -350,6 +351,9 @@ export default class VirtualList extends React.PureComponent<Props, State> {
 
   private getRef = (node: HTMLDivElement): void => {
     this.rootNode = node;
+    if (this.props.ref) {
+      this.props.ref(node);
+    }
   };
 
   private handleScroll = (event: UIEvent) => {


### PR DESCRIPTION
Hello!

I need to be able to imperatively call `ref.scroll({ left: n, behavior: 'smooth' })` on the container of a virtualized list based on users clicking a button - at present there is no way to expose that ref, think the simple approach here should work? Is this something you'd support?

Happy to take a different approach if there's a better way to do this - just let me know and I'd be happy to adjust the PR! 🙂