### PR TITLE
Export enum ALIGNMENT as scrollAlignment to use with scrollToAlignment

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -12,7 +12,10 @@ import {
   sizeProp,
 } from './constants';
 
-export {DIRECTION as ScrollDirection} from './constants';
+export {
+  DIRECTION as ScrollDirection,
+  ALIGNMENT as scrollAlignment,
+} from './constants';
 
 export type ItemPosition = 'absolute' | 'sticky';
 


### PR DESCRIPTION
This PR offers a solution to the following issue:
`https://github.com/clauderic/react-tiny-virtual-list/issues/68`