### PR TITLE
Mark componentWillReceiveProps UNSAFE

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -170,7 +170,7 @@ export default class VirtualList extends React.PureComponent<Props, State> {
     }
   }
 
-  componentWillReceiveProps(nextProps: Props) {
+  UNSAFE_componentWillReceiveProps(nextProps: Props) {
     const {
       estimatedItemSize,
       itemCount,

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -170,6 +170,7 @@ export default class VirtualList extends React.PureComponent<Props, State> {
     }
   }
 
+  // eslint-disable-next-line camelcase
   UNSAFE_componentWillReceiveProps(nextProps: Props) {
     const {
       estimatedItemSize,


### PR DESCRIPTION
See #66. This is the minimum change required for React 17 compatibility.  The warning thrown by React 16, for reference:

```
Warning: componentWillReceiveProps has been renamed, and is not recommended for use. See https://fb.me/react-unsafe-component-lifecycles for details.

      * Move data fetching code or side effects to componentDidUpdate.
      * If you're updating state whenever props change, refactor your code to use memoization techniques or move it to static getDerivedStateFromProps. Learn more at: https://fb.me/react-derived-state
      * Rename componentWillReceiveProps to UNSAFE_componentWillReceiveProps to suppress this warning in non-strict mode. In React 17.x, only the UNSAFE_ name will work. To rename all deprecated lifecycles to their new names, you can run `npx react-codemod rename-unsafe-lifecycles` in your project source folder.
```

